### PR TITLE
Add og:description tag to product pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `og:description` tag to all product pages.
 
 ## [1.0.6] - 2020-06-24
 ### Changed

--- a/react/ProductOpenGraph.tsx
+++ b/react/ProductOpenGraph.tsx
@@ -62,6 +62,7 @@ function ProductOpenGraph() {
     { property: 'og:type', content: 'product' },
     { property: 'og:title', content: title },
     { property: 'og:url', content: url },
+    { property: 'og:description', content: product.metaTagDescription },
     selectedItem
       ? { property: 'product:sku', content: selectedItem.itemId }
       : null,

--- a/react/__tests__/ProductOpenGraph.tsx
+++ b/react/__tests__/ProductOpenGraph.tsx
@@ -138,6 +138,7 @@ test('should have all expected tags', () => {
   const refId = 'ref-1'
   const skuId = 'sku-1'
   const imageUrl = 'image-url'
+  const description = 'Nice shoes'
   const price = 10.5
 
   const productContext = {
@@ -145,6 +146,7 @@ test('should have all expected tags', () => {
       titleTag: title,
       brand,
       productReference: refId,
+      metaTagDescription: description,
     },
     selectedItem: {
       itemId: skuId,
@@ -167,6 +169,7 @@ test('should have all expected tags', () => {
   expect(value('og:type')).toBe('product')
   expect(value('og:title')).toBe(`${title} - Store Components`)
   expect(value('og:url')).toBeDefined()
+  expect(value('og:description')).toBe(description)
   expect(value('product:sku')).toBe(skuId)
   expect(value('product:condition')).toBe('new')
   expect(value('product:brand')).toBe(brand)


### PR DESCRIPTION
#### What problem is this solving?

We don't include a `<meta property="og:description" content="...">` in `store.product` pages. This is useful for [products displayed on Facebook](https://developers.facebook.com/docs/sharing/webmasters?locale=en_US).

#### How to test it?

1. Go to this [Workspace](https://opengraphfix--bennemann.myvtex.com/carteira-slim-com-elastico-verona-preto/p);
2. Inspect the page using your browser's dev tools and look for `<meta property="og:description" content="...">` in the page's HTML.

#### Screenshots or example usage:

<img width="1119" alt="Captura de Tela 2020-06-24 às 17 27 54" src="https://user-images.githubusercontent.com/27777263/85624287-0d912680-b640-11ea-854a-302506fd73f0.png">

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![another-day-in-the-office](https://media.giphy.com/media/yoJC2NtYpt06ubKSd2/giphy.gif)
