### PR TITLE
Add components to render Open Graph tags in home and search pages

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `HomeOpenGraph` and `SearchOpenGraph` components.
 
 ## [1.1.0] - 2020-06-24
 ### Added

--- a/react/HomeOpenGraph.tsx
+++ b/react/HomeOpenGraph.tsx
@@ -1,0 +1,59 @@
+import React, { Fragment } from 'react'
+import {
+  Helmet,
+  useRuntime,
+  RenderContext,
+  canUseDOM,
+} from 'vtex.render-runtime'
+
+// eslint-disable-next-line no-var
+declare var global: {
+  __hostname__: string
+  __pathname__: string
+}
+
+interface MetaTag {
+  property: string
+  content: string
+}
+
+function HomeOpenGraph() {
+  const runtime = useRuntime() as RenderContext
+
+  const { getSettings } = runtime
+
+  const hostname = canUseDOM ? window.location.hostname : global.__hostname__
+  const pathname = canUseDOM ? window.location.pathname : global.__pathname__
+  const url = `https://${hostname}${pathname}`
+  let title = ''
+  let description = ''
+
+  try {
+    const settings = getSettings('vtex.store')
+
+    if (settings) {
+      const { storeName, titleTag, metaTagDescription } = settings
+
+      title = titleTag ?? storeName
+      description = metaTagDescription
+    }
+  } catch (e) {
+    console.error('Failed to load store settings.', e)
+  }
+
+  // TODO: Add og:image tag, which should be customizable via admin
+  const metaTags: MetaTag[] = [
+    { property: 'og:type', content: 'website' },
+    { property: 'og:title', content: title },
+    { property: 'og:url', content: url },
+    { property: 'og:description', content: description },
+  ]
+
+  return (
+    <Fragment>
+      <Helmet meta={metaTags} />
+    </Fragment>
+  )
+}
+
+export default HomeOpenGraph

--- a/react/SearchOpenGraph.tsx
+++ b/react/SearchOpenGraph.tsx
@@ -1,0 +1,42 @@
+import React, { Fragment } from 'react'
+import { Helmet, canUseDOM } from 'vtex.render-runtime'
+
+// eslint-disable-next-line no-var
+declare var global: {
+  __hostname__: string
+  __pathname__: string
+}
+
+interface MetaTag {
+  property: string
+  content: string
+}
+
+function SearchOpenGraph(props: any) {
+  const hasValues = Boolean(props.meta)
+
+  if (!hasValues) {
+    return null
+  }
+
+  const hostname = canUseDOM ? window.location.hostname : global.__hostname__
+  const pathname = canUseDOM ? window.location.pathname : global.__pathname__
+  const url = `https://${hostname}${pathname}`
+  const { title, description } = props.meta
+
+  // TODO: Add support for og:image property
+  const metaTags: MetaTag[] = [
+    { property: 'og:type', content: 'website' },
+    { property: 'og:title', content: title },
+    { property: 'og:url', content: url },
+    { property: 'og:description', content: description ?? '' },
+  ]
+
+  return (
+    <Fragment>
+      <Helmet meta={metaTags} />
+    </Fragment>
+  )
+}
+
+export default SearchOpenGraph

--- a/react/SearchOpenGraph.tsx
+++ b/react/SearchOpenGraph.tsx
@@ -12,13 +12,14 @@ interface MetaTag {
   content: string
 }
 
-function SearchOpenGraph(props: any) {
-  const hasValues = Boolean(props.meta)
-
-  if (!hasValues) {
-    return null
+interface Props {
+  meta: {
+    title: string
+    description: string
   }
+}
 
+function SearchOpenGraph(props: Props) {
   const hostname = canUseDOM ? window.location.hostname : global.__hostname__
   const pathname = canUseDOM ? window.location.pathname : global.__pathname__
   const url = `https://${hostname}${pathname}`


### PR DESCRIPTION
#### What problem is this solving?

We did not include meta tags for Open Graph (used by Facebook) to `store.home` and `store.search` pages.

These tags are useful when these pages are shared on Facebook since they're used to display rich previews, such as:

<img width="442" alt="Captura de Tela 2020-06-26 às 14 50 59" src="https://user-images.githubusercontent.com/27777263/85886420-756c7c00-b7bc-11ea-8e2b-d6afc0cf8f62.png">

This PR implements the necessary components that are to be used by `vtex.store` to add these meta tags in these pages.

#### How to test it?

1. Go to this [Workspace](https://victormiranda--storecomponents.myvtex.com/);
2. Inspect the page using your browser's dev tools and look for meta tags in the HTML, such as

<img width="881" alt="Captura de Tela 2020-06-26 às 14 53 32" src="https://user-images.githubusercontent.com/27777263/85887208-b913b580-b7bd-11ea-8112-1536a67830f1.png">

3. In the same workspace, go to a search page, such as [this one](https://victormiranda--storecomponents.myvtex.com/shoes?_q=Shoes&map=ft) and inspect the page's HTML looking for the same meta tags.

In this test workspace, both this and `vtex.store` are linked, so that these tags are actually added to the pages.

#### Screenshots or example usage:

This is the result of running Facebook's debugger **before** the change:

<img width="1041" alt="Captura de Tela 2020-06-26 às 15 05 13" src="https://user-images.githubusercontent.com/27777263/85887648-96ce6780-b7be-11ea-8502-1b2323f1d454.png">

(from https://developers.facebook.com/tools/debug/?q=https%3A%2F%2Fstoretheme.vtex.com%2F)

Then, **after** the change:

<img width="1029" alt="Captura de Tela 2020-06-26 às 15 07 27" src="https://user-images.githubusercontent.com/27777263/85887778-c7160600-b7be-11ea-8775-086f1b313d89.png">

#### Related to / Depends on

This enables https://github.com/vtex-apps/store/pull/468.

Also, this should be incremented in the future in order to address `og:image` meta tags, which should be editable via Admin. 

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/xSM46ernAUN3y/giphy.gif)
