### PR TITLE
Use spotPrice in product:price:amount field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Send spotPrice in product price.
 
 ## [1.2.0] - 2020-06-29
 ### Added

--- a/react/ProductOpenGraph.tsx
+++ b/react/ProductOpenGraph.tsx
@@ -121,7 +121,7 @@ function productPrice(selectedItem?: SKU): MetaTag | null {
 
   return {
     property: 'product:price:amount',
-    content: `${seller.commertialOffer.Price}`,
+    content: `${seller.commertialOffer.spotPrice}`,
   }
 }
 

--- a/react/__tests__/ProductOpenGraph.tsx
+++ b/react/__tests__/ProductOpenGraph.tsx
@@ -74,7 +74,7 @@ test('should show availability with oos when no item is available', () => {
 })
 
 test('should render price', () => {
-  const price = 10
+  const spotPrice = 10
   const productContext = {
     product: {},
     selectedItem: {
@@ -82,7 +82,7 @@ test('should render price', () => {
       sellers: [
         {
           commertialOffer: {
-            Price: price,
+            spotPrice,
             AvailableQuantity: 1,
           },
         },
@@ -94,7 +94,7 @@ test('should render price', () => {
 
   const tag = getByTestId('product:price:amount')
 
-  expect(tag.innerHTML).toBe(`${price}`)
+  expect(tag.innerHTML).toBe(`${spotPrice}`)
 })
 
 test('should render images', () => {
@@ -139,7 +139,7 @@ test('should have all expected tags', () => {
   const skuId = 'sku-1'
   const imageUrl = 'image-url'
   const description = 'Nice shoes'
-  const price = 10.5
+  const spotPrice = 10.5
 
   const productContext = {
     product: {
@@ -154,7 +154,7 @@ test('should have all expected tags', () => {
       sellers: [
         {
           commertialOffer: {
-            Price: price,
+            spotPrice,
             AvailableQuantity: 1,
           },
         },
@@ -177,5 +177,5 @@ test('should have all expected tags', () => {
   expect(value('product:price:currency')).toBe('USD')
   expect(value('og:image')).toBe(imageUrl)
   expect(value('product:availability')).toBe('instock')
-  expect(value('product:price:amount')).toBe(`${price}`)
+  expect(value('product:price:amount')).toBe(`${spotPrice}`)
 })

--- a/react/package.json
+++ b/react/package.json
@@ -20,7 +20,7 @@
     "@types/react-intl": "^2.3.17",
     "@vtex/test-tools": "^3.0.0",
     "apollo-client": "^2.5.1",
-    "typescript": "3.8.3"
+    "typescript": "3.9.7"
   },
   "version": "1.2.0"
 }

--- a/react/typings/vtex.product-context.d.ts
+++ b/react/typings/vtex.product-context.d.ts
@@ -83,6 +83,7 @@ declare module 'vtex.product-context' {
         }
         Price: string
         ListPrice: string
+        spotPrice: string
         PriceWithoutDiscount: string
         RewardValue: string
         PriceValidUntil: string

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -4607,10 +4607,10 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+typescript@3.9.7:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 typescript@^3.7.3:
   version "3.9.5"


### PR DESCRIPTION
#### What problem is this solving?

Our objective is to always show the lowest price in google shop to gain more clicks and increase conversion. 

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://opengraph--compracerta.myvtex.com/geladeira-brastemp-frost-free-375-litros---brm45hk-2004138/p)

#### Screenshots or example usage:
My workspace:
![image](https://user-images.githubusercontent.com/16908590/98848762-f4431800-2430-11eb-9083-bd890c50e9be.png)

Production:
![image](https://user-images.githubusercontent.com/16908590/98848850-13da4080-2431-11eb-9a76-75de8a6baf30.png)


#### Related to / Depends on

This pull request is almost the same of that: https://github.com/vtex-apps/structured-data/pull/24 (non-break changes :D )

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

When the conversion rate increase because this pr:
![](https://media.giphy.com/media/d6LGWQbs3Y3yUESdjm/giphy.gif)
