### PR TITLE
Add new meta tag product:item_group_id to support Facebook's Product Variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `product:item_group_id` to support Facebook variants.
 
 ## [1.2.1] - 2020-11-12
 ### Fixed

--- a/react/ProductOpenGraph.tsx
+++ b/react/ProductOpenGraph.tsx
@@ -70,6 +70,7 @@ function ProductOpenGraph() {
     { property: 'product:brand', content: product.brand },
     { property: 'product:retailer_item_id', content: product.productReference },
     { property: 'product:price:currency', content: `${currency}` },
+    { property: 'product:item_group_id', content: product.productId },
     ...productImage(selectedItem),
     productAvailability(selectedItem),
     productPrice(selectedItem),


### PR DESCRIPTION
References:
- https://developers.facebook.com/docs/marketing-api/catalog/reference/#og-tags
- https://developers.facebook.com/docs/marketing-api/catalog/guides/microdata-tags
- https://developers.facebook.com/docs/marketing-api/audiences/guides/dynamic-product-audiences#content_type

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](Link goes here!)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
