### PR TITLE
fix: reverse og:image array.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "open-graph",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "title": "Open Graph",
   "description": "Open Graph tags",
   "builders": {

--- a/react/ProductOpenGraph.tsx
+++ b/react/ProductOpenGraph.tsx
@@ -98,6 +98,7 @@ function productImage(selectedItem?: SKU): Array<MetaTag | {}> {
       ],
       []
     )
+    .reverse()
 }
 
 function productAvailability(selectedItem?: SKU): MetaTag {

--- a/react/__tests__/ProductOpenGraph.tsx
+++ b/react/__tests__/ProductOpenGraph.tsx
@@ -127,9 +127,9 @@ test('should render images', () => {
   const tags = getAllByTestId('og:image')
 
   expect(tags).toHaveLength(3)
-  expect(tags[0].innerHTML).toBe(image1)
+  expect(tags[2].innerHTML).toBe(image1)
   expect(tags[1].innerHTML).toBe(image2)
-  expect(tags[2].innerHTML).toBe(image3)
+  expect(tags[0].innerHTML).toBe(image3)
 })
 
 test('should have all expected tags', () => {


### PR DESCRIPTION
#### What problem is this solving?

In this moment, VTEX is showing the third image if the array of product images has 3 or more images. In the other hand the array show the lastest image when it has 2 or less elements.

#### How to test it?
- https://imagearray--belcorp.myvtex.com/
- https://imagearray--esika.myvtex.com/

#### Screenshots or example usage:

#### Describe alternatives you've considered, if any.

I used a reverse array method to repair this, reversing the array and showing the lastest in first place.

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
