### PR TITLE
Add canonical prop to SearchOpenGraph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `canonical` prop to `SearchOpenGraph` to support consistency between `<link rel="canonical">` tags and `og:url` metatags
+
 ## [1.2.1] - 2020-11-12
 ### Fixed
 - Send spotPrice in product price.

--- a/react/SearchOpenGraph.tsx
+++ b/react/SearchOpenGraph.tsx
@@ -16,6 +16,7 @@ interface Props {
   meta: {
     title: string
     description: string
+    canonical?: string
   }
 }
 
@@ -23,13 +24,13 @@ function SearchOpenGraph(props: Props) {
   const hostname = canUseDOM ? window.location.hostname : global.__hostname__
   const pathname = canUseDOM ? window.location.pathname : global.__pathname__
   const url = `https://${hostname}${pathname}`
-  const { title, description } = props.meta
+  const { title, description, canonical } = props.meta
 
   // TODO: Add support for og:image property
   const metaTags: MetaTag[] = [
     { property: 'og:type', content: 'website' },
     { property: 'og:title', content: title },
-    { property: 'og:url', content: url },
+    { property: 'og:url', content: canonical ?? url },
     { property: 'og:description', content: description ?? '' },
   ]
 


### PR DESCRIPTION
#### What problem is this solving?

Search page canonical URLs commonly include query strings, but up until now our open-graph app has been stripping them out. This PR adds support for a `canonical` prop on the `SearchOpenGraph` component that will allow another app (such as `vtex.store`) to set a canonical URL which will override the URL generated by the open-graph app, ensuring consistency between the two metatag types. 

#### How to test it?

Linked here: https://arthur--budgetgolf.myvtex.com/black%20shoes?_q=black%20shoes&map=ft

In this example, `vtex.store` provides a canonical prop which includes the query strings from the above URL. You can see that this now passes through and is reflected in the `og:url` tag. 