### PR TITLE
Enrich our OG tags with some extra info to help with Synerise integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `product:retailer_part_no` and `product:category` to the ProductOpenGraph.
+
 ## [1.3.0] - 2024-02-09
 
 ### Added

--- a/react/ProductOpenGraph.tsx
+++ b/react/ProductOpenGraph.tsx
@@ -142,8 +142,8 @@ function productPrice({
 }
 
 function productCategories(product?: Product) {
-  if (!product || !product.categories || !product.categories.length) {
-    return [null]
+  if (!product?.categories?.length) {
+    return []
   }
 
   return product.categories.map(category => ({

--- a/react/ProductOpenGraph.tsx
+++ b/react/ProductOpenGraph.tsx
@@ -69,7 +69,7 @@ function ProductOpenGraph() {
       ? { property: 'product:sku', content: selectedItem.itemId }
       : null,
     selectedItem
-      ? { property: 'product:retailer_part_no', content: selectedItem.itemId } // Used in the Synerise integration
+      ? { property: 'product:retailer_part_no', content: product.productId } // Used in the Synerise integration
       : null,
     { property: 'product:retailer_item_id', content: product.productReference },
     { property: 'product:condition', content: 'new' },

--- a/react/ProductOpenGraph.tsx
+++ b/react/ProductOpenGraph.tsx
@@ -67,6 +67,9 @@ function ProductOpenGraph() {
     selectedItem
       ? { property: 'product:sku', content: selectedItem.itemId }
       : null,
+    selectedItem
+      ? { property: 'product:retailer_part_no', content: selectedItem.itemId } // Used in the Synerise integration
+      : null,
     { property: 'product:condition', content: 'new' },
     { property: 'product:brand', content: product.brand },
     { property: 'product:retailer_item_id', content: product.productReference },

--- a/react/ProductOpenGraph.tsx
+++ b/react/ProductOpenGraph.tsx
@@ -5,7 +5,7 @@ import {
   RenderContext,
   canUseDOM,
 } from 'vtex.render-runtime'
-import { ProductContext, SKU } from 'vtex.product-context'
+import { ProductContext, SKU, Product } from 'vtex.product-context'
 
 import useAppSettings from './hooks/useAppSettings'
 
@@ -75,10 +75,7 @@ function ProductOpenGraph() {
     { property: 'product:condition', content: 'new' },
     { property: 'product:brand', content: product.brand },
     { property: 'product:price:currency', content: `${currency}` },
-    ...product.categories.map(category => ({
-      property: 'product:category',
-      content: category,
-    })),
+    ...productCategories(product),
     ...productImage(selectedItem),
     productPrice({ selectedItem, disableOffers }),
     productAvailability(selectedItem),
@@ -142,6 +139,17 @@ function productPrice({
     property: 'product:price:amount',
     content: `${seller.commertialOffer.spotPrice}`,
   }
+}
+
+function productCategories(product?: Product) {
+  if (!product || !product.categories || !product.categories.length) {
+    return [null]
+  }
+
+  return product.categories.map(category => ({
+    property: 'product:category',
+    content: category,
+  }))
 }
 
 export default ProductOpenGraph

--- a/react/ProductOpenGraph.tsx
+++ b/react/ProductOpenGraph.tsx
@@ -21,6 +21,7 @@ interface MetaTag {
 }
 
 function ProductOpenGraph() {
+  const { disableOffers } = useAppSettings()
   const productContext = useContext(ProductContext) as ProductContext
   const runtime = useRuntime() as RenderContext
   const hasValue = productContext?.product
@@ -75,8 +76,8 @@ function ProductOpenGraph() {
     { property: 'product:retailer_item_id', content: product.productReference },
     { property: 'product:price:currency', content: `${currency}` },
     ...productImage(selectedItem),
+    productPrice({ selectedItem, disableOffers }),
     productAvailability(selectedItem),
-    productPrice(selectedItem),
   ].filter(Boolean) as MetaTag[]
 
   return (
@@ -114,8 +115,13 @@ function productAvailability(selectedItem?: SKU): MetaTag {
   return { property: 'product:availability', content: `${availability}` }
 }
 
-function productPrice(selectedItem?: SKU): MetaTag | null {
-  const { disableOffers } = useAppSettings()
+function productPrice({
+  selectedItem,
+  disableOffers,
+}: {
+  selectedItem?: SKU
+  disableOffers: boolean
+}): MetaTag | null {
   const seller = selectedItem?.sellers.find(
     ({ commertialOffer }) => commertialOffer.AvailableQuantity > 0
   )

--- a/react/ProductOpenGraph.tsx
+++ b/react/ProductOpenGraph.tsx
@@ -71,10 +71,14 @@ function ProductOpenGraph() {
     selectedItem
       ? { property: 'product:retailer_part_no', content: selectedItem.itemId } // Used in the Synerise integration
       : null,
+    { property: 'product:retailer_item_id', content: product.productReference },
     { property: 'product:condition', content: 'new' },
     { property: 'product:brand', content: product.brand },
-    { property: 'product:retailer_item_id', content: product.productReference },
     { property: 'product:price:currency', content: `${currency}` },
+    ...product.categories.map(category => ({
+      property: 'product:category',
+      content: category,
+    })),
     ...productImage(selectedItem),
     productPrice({ selectedItem, disableOffers }),
     productAvailability(selectedItem),


### PR DESCRIPTION
#### What problem is this solving?

- For the integration work properly we need some specific data to be presented in the OG tags. We were missing `product:retailer_part_no` which is the ProductID and the categories `product:category`.

Reference: https://hub.synerise.com/developers/web/og-tags/

#### How to test it?

[Workspace](https://felipe--biggy.myvtex.com/camisa-masculina/p?__bindingAddress=biggy.myvtex.com/)

#### Screenshots or example usage:

<img width="996" alt="Screenshot 2025-01-08 at 12 08 23" src="https://github.com/user-attachments/assets/343566c0-3d06-48ed-be28-b44dd3bff12b" />

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
