### PR TITLE
fix/removeStoreNameTitle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.4.1] - 2025-07-31
+
+### Fixed
+- The og:title was not respecting the removeStoreNameTitle tag from store settings.
+
 ### Changed
 
 - Update GitHub actions/cache to v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [1.4.1] - 2025-07-31
-
 ### Fixed
 - The og:title was not respecting the removeStoreNameTitle tag from store settings.
 

--- a/react/ProductOpenGraph.tsx
+++ b/react/ProductOpenGraph.tsx
@@ -45,16 +45,21 @@ function ProductOpenGraph() {
   let title = titleTag || productName
 
 try {
+  
   const settings = getSettings('vtex.store')
+  
     if (!settings.removeStoreNameTitle) {
       const { storeName, titleTag: storeTitleTag } = settings
       const suffix = (storeTitleTag || storeName) && ` - ${storeTitleTag || storeName}`
+      
       if (suffix) {
         title += suffix
       }
     }
 } catch (e) {
+  
   console.error('Failed to suffix store name in title.', e)
+  
 }
 
   const metaTags = [

--- a/react/ProductOpenGraph.tsx
+++ b/react/ProductOpenGraph.tsx
@@ -44,23 +44,21 @@ function ProductOpenGraph() {
 
   let title = titleTag || productName
 
-try {
-  
-  const settings = getSettings('vtex.store')
+  try {
+    const settings = getSettings('vtex.store')
   
     if (!settings.removeStoreNameTitle) {
       const { storeName, titleTag: storeTitleTag } = settings
-      const suffix = (storeTitleTag || storeName) && ` - ${storeTitleTag || storeName}`
-      
+      const suffix = 
+        (storeTitleTag || storeName) && ` - ${storeTitleTag || storeName}`
+
       if (suffix) {
         title += suffix
       }
     }
-} catch (e) {
-  
-  console.error('Failed to suffix store name in title.', e)
-  
-}
+  } catch (e) {
+   console.error('Failed to suffix store name in title.', e)
+  }
 
   const metaTags = [
     { property: 'og:type', content: 'product' },

--- a/react/ProductOpenGraph.tsx
+++ b/react/ProductOpenGraph.tsx
@@ -50,7 +50,7 @@ function ProductOpenGraph() {
     if (!settings.removeStoreNameTitle) {
       const { storeName, titleTag: storeTitleTag } = settings
       const suffix =
-       (storeTitleTag || storeName) && ` - ${storeTitleTag || storeName}`
+        (storeTitleTag || storeName) && ` - ${storeTitleTag || storeName}`
 
       if (suffix) {
         title += suffix

--- a/react/ProductOpenGraph.tsx
+++ b/react/ProductOpenGraph.tsx
@@ -44,21 +44,18 @@ function ProductOpenGraph() {
 
   let title = titleTag || productName
 
-  try {
-    const settings = getSettings('vtex.store')
-  
-    if (settings) {
-      if (!settings.removeStoreNameTitle) {
-        const { storeName, titleTag: storeTitleTag } = settings
-        const suffix = (storeTitleTag || storeName) && ` - ${storeTitleTag || storeName}`
-        if (suffix) {
-          title += suffix
-        }
+try {
+  const settings = getSettings('vtex.store')
+    if (!settings.removeStoreNameTitle) {
+      const { storeName, titleTag: storeTitleTag } = settings
+      const suffix = (storeTitleTag || storeName) && ` - ${storeTitleTag || storeName}`
+      if (suffix) {
+        title += suffix
       }
     }
-  } catch (e) {
-    console.error('Failed to suffix store name in title.', e)
-  }
+} catch (e) {
+  console.error('Failed to suffix store name in title.', e)
+}
 
   const metaTags = [
     { property: 'og:type', content: 'product' },

--- a/react/ProductOpenGraph.tsx
+++ b/react/ProductOpenGraph.tsx
@@ -46,18 +46,18 @@ function ProductOpenGraph() {
 
   try {
     const settings = getSettings('vtex.store')
-  
+
     if (!settings.removeStoreNameTitle) {
       const { storeName, titleTag: storeTitleTag } = settings
-      const suffix = 
-        (storeTitleTag || storeName) && ` - ${storeTitleTag || storeName}`
+      const suffix =
+       (storeTitleTag || storeName) && ` - ${storeTitleTag || storeName}`
 
       if (suffix) {
         title += suffix
       }
     }
   } catch (e) {
-   console.error('Failed to suffix store name in title.', e)
+    console.error('Failed to suffix store name in title.', e)
   }
 
   const metaTags = [

--- a/react/ProductOpenGraph.tsx
+++ b/react/ProductOpenGraph.tsx
@@ -46,14 +46,14 @@ function ProductOpenGraph() {
 
   try {
     const settings = getSettings('vtex.store')
-
+  
     if (settings) {
-      const { storeName, titleTag: storeTitleTag } = settings
-      const suffix =
-        (storeTitleTag || storeName) && ` - ${storeTitleTag || storeName}`
-
-      if (suffix) {
-        title += suffix
+      if (!settings.removeStoreNameTitle) {
+        const { storeName, titleTag: storeTitleTag } = settings
+        const suffix = (storeTitleTag || storeName) && ` - ${storeTitleTag || storeName}`
+        if (suffix) {
+          title += suffix
+        }
       }
     }
   } catch (e) {


### PR DESCRIPTION
Fix the og:title not taking into consideration the removeStoreNameTitle tag from store settings

#### What problem is this solving?

The og:title was not respecting the removeStoreNameTitle tag from store settings

#### How to test it?

You can test the fix on this workspace:
https://ccanelas--bellapiel.myvtex.com/isdinceutics-k-ox-eyes-3608/p

#### Screenshots or example usage:
After
![image](https://github.com/user-attachments/assets/cdc1a356-b5f2-496b-815e-a1c2abf9966e)

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExaDQzMndhMTNucGp1cnZiajgxczJtajllb3o4bmxwbWtyemdxMGo4cCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/xTiN0CNHgoRf1Ha7CM/giphy.gif)
